### PR TITLE
descriptor text not nested in descriptor search

### DIFF
--- a/alps_siren.asciidoc
+++ b/alps_siren.asciidoc
@@ -142,8 +142,9 @@ ALPS profile to a Siren representation is rather straightforward.
 ----
 <alps>
   <link rel="self" href="http://alps.io/profiles/search" />
-  <descriptor id="text" type="semantic" />
-  <descriptor id="search" type="safe" />
+  <descriptor id="search" type="safe" >
+    <descriptor id="text" type="semantic" />
+  </descriptor>
 </alps>
 ----
 


### PR DESCRIPTION
http://tools.ietf.org/html/draft-amundsen-richardson-foster-alps-01#section-1.3 shows that input field descriptors are nested inside the surrounding state transition descriptor:

```
 <descriptor id="collection" type="safe" rt="contact">
   <descriptor id="nameSearch" type="semantic" />
 </descriptor>
```
